### PR TITLE
bugfix(#830): Use silent message for unavailable contact information

### DIFF
--- a/src/components/unavailable-end-user-contacts/unavailable-end-user-contacts.tsx
+++ b/src/components/unavailable-end-user-contacts/unavailable-end-user-contacts.tsx
@@ -14,7 +14,7 @@ import {
   sendMessagePreview,
   endChat,
   setContactFormComment,
-  sendNewMessage,
+  sendNewSilentMessage,
 } from "../../slices/chat-slice";
 import { Message } from "../../model/message-model";
 import StyledButton from "../styled-components/styled-button";
@@ -81,7 +81,7 @@ const UnavailableEndUserContacts = (): JSX.Element => {
           contactMsgId,
           t
         );
-        dispatch(sendNewMessage(commentMsg));
+        dispatch(sendNewSilentMessage(commentMsg));
       }
 
       dispatch(


### PR DESCRIPTION
- Sends silent message on unavailable end user contact information submission.

- Fixes issue where bot sends unnecessary message after chat is finalized meaning that contact details are submitted with comment and chat window is automatically closed on user side.