### PR TITLE
Hot-Fix: Markdown open links in new tab

### DIFF
--- a/src/components/chat-message/message-types/Markdownify.tsx
+++ b/src/components/chat-message/message-types/Markdownify.tsx
@@ -6,7 +6,7 @@ interface MarkdownifyProps {
 }
 const Markdownify: React.FC<MarkdownifyProps> = ({ message }) => (
   <div>
-    <Markdown target="_blank" options={{ enforceAtxHeadings: true }}>
+    <Markdown target="_blank" options={{ enforceAtxHeadings: true, overrides: { a: { props: { target: "_blank" } } } }}>
       {message ?? ""}
     </Markdown>
   </div>


### PR DESCRIPTION
- Fixed Open links in new tab from within 'markdown-to-jsx' package