### PR TITLE
Chat Destroy

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -40,6 +40,11 @@ export enum CHAT_MODES {
   FREE = 'free',
 }
 
+export enum CHAT_SESSIONS {
+  SESSION_ID_KEY = "tabId",
+  SESSION_STATE_KEY = "sessionTabs"
+}
+
 export enum CHAT_STATUS {
   ENDED = 'ENDED',
   OPEN = 'OPEN',

--- a/src/hooks/use-reload-chat-end-effect.ts
+++ b/src/hooks/use-reload-chat-end-effect.ts
@@ -11,18 +11,17 @@ const useReloadChatEndEffect = () => {
 
   useEffect(() => {
     dispatch(removeChatFromTerminationQueue());
-  }, []);
+  }, [dispatch]);
 
   useEffect(() => {
     const handleBeforeUnload = () => {
       if (chatId && isRedirectPathEmpty() && isLastSession()) {
-        localStorage.setItem("sessions", "1");
         dispatch(addChatToTerminationQueue());
       }
     };
 
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "F5" || (event.ctrlKey && event.key === "r")) {
+      if (event.key !== "F5" && (event.ctrlKey && event.key === "r")) {
         handleBeforeUnload();
       }
     };
@@ -34,7 +33,7 @@ const useReloadChatEndEffect = () => {
       window.removeEventListener("beforeunload", handleBeforeUnload);
       window.removeEventListener("keydown", handleKeyDown);
     };
-  }, [chatId]);
+  }, [chatId, dispatch]);
 }
 
 export default useReloadChatEndEffect;

--- a/src/utils/browser-utils.ts
+++ b/src/utils/browser-utils.ts
@@ -2,7 +2,6 @@ import {CHAT_SESSIONS} from "../constants";
 
 export const isLastSession = (): boolean => {
   const currentState = JSON.parse(localStorage.getItem(CHAT_SESSIONS.SESSION_STATE_KEY) as string) || { ids: [], count: 0 };
-  localStorage.setItem('deb2', currentState.count.toString())
   return currentState.count <= 1;
 }
 

--- a/src/utils/browser-utils.ts
+++ b/src/utils/browser-utils.ts
@@ -1,6 +1,9 @@
-export const isLastSession = () => {
-  const sessions = localStorage.getItem("sessions");
-  return sessions && parseInt(sessions) === 1;
+import {CHAT_SESSIONS} from "../constants";
+
+export const isLastSession = (): boolean => {
+  const currentState = JSON.parse(localStorage.getItem(CHAT_SESSIONS.SESSION_STATE_KEY) as string) || { ids: [], count: 0 };
+  localStorage.setItem('deb2', currentState.count.toString())
+  return currentState.count <= 1;
 }
 
 export const wasPageReloaded = () => {

--- a/src/utils/generators.ts
+++ b/src/utils/generators.ts
@@ -1,0 +1,8 @@
+export const generateUEID = () => {
+    let first: string | number = (Math.random() * 46656) | 0;
+    let second: string | number = (Math.random() * 46656) | 0;
+    first = ('000' + first.toString(36)).slice(-3);
+    second = ('000' + second.toString(36)).slice(-3);
+
+    return first + second;
+};


### PR DESCRIPTION
- Fixed termination init trigger
- Refactored tab session to have ids/count and to use session storage to hold unique id for each opened tab.

Related [task](https://github.com/buerokratt/Buerokratt-Chatbot/issues/1117).