### PR TITLE
1130 Chat widget rows

### DIFF
--- a/src/components/chat-keypad/chat-keypad.module.scss
+++ b/src/components/chat-keypad/chat-keypad.module.scss
@@ -18,6 +18,7 @@
     justify-content: center;
     align-items: center;
     margin: 1em;
+    margin-bottom: 2em;
     margin-right: 0.5em;
     flex: 1;
     border: 0;
@@ -25,7 +26,7 @@
     border-bottom: 1px solid $color-primary;
     border-radius: 0;
     padding-bottom: 5px;
-    height: 1.5em;
+    height: 5.6em;
     resize: none;
     overflow: hidden;
     color: inherit;

--- a/src/components/chat-keypad/chat-keypad.module.scss
+++ b/src/components/chat-keypad/chat-keypad.module.scss
@@ -17,20 +17,21 @@
     display: inline-flex;
     justify-content: center;
     align-items: center;
-    margin: 1em;
-    margin-bottom: 2em;
-    margin-right: 0.5em;
+    margin: 1em 0.5em 2em 1em;
     flex: 1;
     border: 0;
     outline: none;
     border-bottom: 1px solid $color-primary;
     border-radius: 0;
-    padding-bottom: 5px;
-    height: 5.6em;
+    padding-bottom: 2px;
     resize: none;
-    overflow: hidden;
+    overflow: visible;
     color: inherit;
     font: inherit;
+    line-height: 1.5;
+    height: auto;
+    max-height: 5.6em;
+
     &::placeholder {
       color: $color-placeholder-gray;
     }

--- a/src/components/chat-keypad/chat-keypad.tsx
+++ b/src/components/chat-keypad/chat-keypad.tsx
@@ -46,6 +46,7 @@ const ChatKeyPad = (): JSX.Element => {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
   const hiddenFileInputRef = useRef<HTMLInputElement | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const handleUploadClick = () => {
     hiddenFileInputRef.current?.click();
@@ -67,6 +68,18 @@ const ChatKeyPad = (): JSX.Element => {
       base64: base64,
     });
   };
+
+  const adjustHeight = () => {
+    const textarea = textareaRef.current;
+    if (textarea) {
+      textarea.style.height = "1em";
+      textarea.style.height = `${textarea.scrollHeight}px`;
+    }
+  };
+
+  useEffect(() => {
+    adjustHeight();
+  }, []);
 
   const handleTextFeedback = () => {
     if (!feedback.isFeedbackRatingGiven) {
@@ -169,6 +182,7 @@ const ChatKeyPad = (): JSX.Element => {
       <KeypadErrorMessage>{errorMessage}</KeypadErrorMessage>
       <div className={`${keypadClasses}`}>
         <textarea
+          ref={textareaRef}
           disabled={userInputFile ? true : isKeypadDisabled}
           aria-label={t("keypad.input.label")}
           className={`${styles.input}`}
@@ -177,6 +191,7 @@ const ChatKeyPad = (): JSX.Element => {
           onChange={(e) => {
             setUserInput(e.target.value);
             setErrorMessage("");
+            adjustHeight();
           }}
           onKeyDown={(event) => {
             if (event.key === "Enter") {
@@ -187,7 +202,10 @@ const ChatKeyPad = (): JSX.Element => {
               }
             }
           }}
-          onKeyUp={handleKeyUp}
+          onKeyUp={(e) => {
+            handleKeyUp();
+            adjustHeight();
+          }}
         />
         <input type="file" ref={hiddenFileInputRef} onChange={handleFileChange} style={{ display: "none" }} />
 


### PR DESCRIPTION
- Chat widget would expand up to 4 rows of user input to show
- Added scrolling to text inside


Related [task](https://github.com/buerokratt/Buerokratt-Chatbot/issues/1130).